### PR TITLE
[Refactor] Refactor the JobList Object

### DIFF
--- a/core/job_list/job_list.py
+++ b/core/job_list/job_list.py
@@ -162,13 +162,6 @@ class JobList:
         for item in intersect_list:
             self.__jobs.pop(self.__jobs.index(item))
 
-        # # Check the equality of the jobs_run in job list
-        # for self.__jobs_run in jobs_list:
-        #     for job_from_jobs in self.__jobs:
-        #         if job_from_jobs == job_from_job_file["file_name"]:
-        #             self.__rated_student.append(self.__student_data["run_job"].pop(
-        #                 self.__student_data["run_job"].index(stu)))
-
     def load_jobs(self, job_file):
         key_list, split_list = self.__split()
         self.__read_jobs_from_dir(key_list, split_list)

--- a/core/job_list/job_list.py
+++ b/core/job_list/job_list.py
@@ -18,22 +18,11 @@ class JobList:
         """
         self.__path_to_run = path_to_run
         self.__job_draft = job_draft
-
-        self.__work = 0
         self.__student_data = {"run_job": []}
         self.__invalid_file_name = []
         self.__key_list = []
         self.__split_list = []
         self.__rated_student = []
-
-    @property
-    def work(self):
-        """[work]
-
-        Returns:
-            int : amount or work
-        """
-        return self.__work
 
     @property
     def student_data(self):
@@ -129,13 +118,6 @@ class JobList:
         self.__key_list = key_list
         self.__split_list = split_list
 
-    def __count(self):
-        """[count]
-        count amount of work and keep it in self.__work
-        """
-        filename = self.__read_name()
-        self.__work = len(filename)
-
     def __append_studata(self):
         """[append student data]
         put the information that has been categorized into the list/json (self.__student_data)
@@ -155,7 +137,6 @@ class JobList:
     def run(self):
         self.__split()
         self.__append_studata()
-        self.__count()
 
     def check_job_done(self, job_file):
         """[check job done]

--- a/core/job_list/job_list.py
+++ b/core/job_list/job_list.py
@@ -61,7 +61,7 @@ class JobList:
         ]
 
         Returns:
-            list : List of the job object that has already been run. 
+            list : List of the job object that has already been run.
         """
         return self.__jobs_run
 

--- a/core/job_list/job_list.py
+++ b/core/job_list/job_list.py
@@ -18,40 +18,54 @@ class JobList:
         """
         self.__path_to_run = path_to_run
         self.__job_draft = job_draft
-        self.__student_data = {"run_job": []}
-        self.__invalid_file_name = []
-        self.__key_list = []
-        self.__split_list = []
+        self.__jobs = []
+        self.__jobs_all = []
+        self.__jobs_run = []
+        self.__unknown_files = []
+
+        # Change name
         self.__rated_student = []
 
     @property
-    def student_data(self):
-        """[student data]
-
+    def jobs(self):
+        """[jobs]
+        Data Structure:
+        [
+            `Job Object`
+        ]
         Returns:
-            dict(.json): dictionary of student data that keep | the following the given draft.json [zip_file_draft]
+            List: Contain the List of the `Job` Object (Job List to workon)
         """
-        return self.__student_data
+        return self.__jobs
 
     @property
-    def invalid_file_name(self):
+    def unknown_files(self):
         """[invalid file name]
 
+        Data Structure:
+        [
+            "{File Name}.zip"
+        ]
+
         Returns:
-            list : list of the file.zip with the name is invalid
+            list : Contain the file name that can't be parsed by using the `job_draft.zip_file_draft`
         """
-        return self.__invalid_file_name
+        return self.__unknown_files
 
     @property
-    def rated_student(self):
+    def job_runs(self):
         """[rated student]
+        Data Structure:
+        [
+            Job Object
+        ]
 
         Returns:
-            list : list of student that has been rated
+            list : List of the job object that has already been run. 
         """
-        return self.__rated_student
+        return self.__jobs_run
 
-    def __read_name(self):
+    def __read_jobs_file(self):
         """[read name]
 
         Returns:
@@ -63,7 +77,7 @@ class JobList:
                 file_name.append(str(file))
         return file_name
 
-    def __check_file_name(self, stu_data, file_name):
+    def __check_file_name(self, stu_data, file_name, split_list):
         """[check file name]
 
         Args:
@@ -75,15 +89,15 @@ class JobList:
         """
         for i in stu_data:
             if ".zi" in i:
-                self.__invalid_file_name.append(file_name)
+                self.__unknown_files.append(file_name)
                 return False
-            for j in self.__split_list:
+            for j in split_list:
                 if j in i:
                     self.__invalid_file_name.append(file_name)
                     return False
         return True
 
-    def __split_name(self, file_name):
+    def __split_name(self, file_name, split_list):
         """[split name]
             split file so it can be classification
         Args:
@@ -92,7 +106,6 @@ class JobList:
         Returns:
             list : list of string that following that draft.json (zip_file_draft)
         """
-        split_list = self.__split_list
         stu_data = []
         for i in split_list:
             value_splited = file_name[:file_name.find(i)]
@@ -115,38 +128,83 @@ class JobList:
             split_list.append(
                 zip_draft[zip_draft.find("}")+1:zip_draft.find("}")+2])
             zip_draft = zip_draft[zip_draft.find("}")+1:]
-        self.__key_list = key_list
-        self.__split_list = split_list
+        return (key_list, split_list)
 
-    def __append_studata(self):
+    def __read_jobs_from_dir(self, key_list, split_list):
         """[append student data]
         put the information that has been categorized into the list/json (self.__student_data)
         """
-        filename = self.__read_name()
-        stu_data = []
+        filename = self.__read_jobs_file()
         for i in filename:
-            person_data = {}
-            person_data["file_name"] = i
-            if self.__check_file_name(self.__split_name(i), i) is False:
+            file_name = i
+            job_vars = {}
+            if self.__check_file_name(self.__split_name(i, split_list), i, split_list) is False:
                 continue
-            for j, k in zip(self.__split_name(i), self.__key_list):
-                person_data[k] = j
-            stu_data.append(person_data)
-        self.__student_data["run_job"] = stu_data
+            for j, k in zip(self.__split_name(i, split_list), key_list):
+                job_vars[k] = j
+            self.__jobs.append(Job(file_name=file_name, job_vars=job_vars))
 
-    def run(self):
-        self.__split()
-        self.__append_studata()
-
-    def check_job_done(self, job_file):
+    def __categorize_job(self, job_file):
         """[check job done]
         check that which student have been rated and remove them form self.__student_data
         Args:
             job_file (job.json): list of student that has been rated
         """
-        job_list = job_file["run_job"]
-        for done_stu in job_list:
-            for stu in self.__student_data["run_job"]:
-                if done_stu["student_id"] == stu["student_id"]:
-                    self.__rated_student.append(self.__student_data["run_job"].pop(
-                        self.__student_data["run_job"].index(stu)))
+        # Convert Job File to Job object
+        for item in job_file["run_job"]:
+            file_name = item["file_name"]
+            item.pop("file_name")
+            job_vars = item
+            self.__jobs_run.append(Job(file_name=file_name, job_vars=job_vars))
+
+        intersect_list = [
+            value for value in self.__jobs if value in self.__jobs_run]
+        for item in intersect_list:
+            self.__jobs.pop(self.__jobs.index(item))
+
+        # # Check the equality of the jobs_run in job list
+        # for self.__jobs_run in jobs_list:
+        #     for job_from_jobs in self.__jobs:
+        #         if job_from_jobs == job_from_job_file["file_name"]:
+        #             self.__rated_student.append(self.__student_data["run_job"].pop(
+        #                 self.__student_data["run_job"].index(stu)))
+
+    def load_jobs(self, job_file):
+        key_list, split_list = self.__split()
+        self.__read_jobs_from_dir(key_list, split_list)
+        self.__categorize_job(job_file)
+
+
+class Job:
+
+    def __init__(self, file_name="", job_vars={}):
+        """The Constructure Object of Job
+        """
+        self.__file_name = file_name
+        self.__job_vars = job_vars
+
+    def generate_dict_report(self):
+        dict_data = {
+            "file_name": self.__file_name
+        }
+        dict_data.update(self.__job_vars)
+        return dict_data
+
+    def __eq__(self, compare):
+        """The descript the Equality of the object
+        By using `file_name`
+        """
+        return compare.file_name == self.__file_name
+
+    def __hash__(self):
+        return hash(str(self))
+
+    @property
+    def file_name(self):
+        # The Property of file_name attribute
+        return self.__file_name
+
+    @property
+    def job_vars(self):
+        # The Property of job_vars attribute
+        return self.__job_vars

--- a/core/job_list/test_job_list.py
+++ b/core/job_list/test_job_list.py
@@ -1,6 +1,7 @@
+from job_list import JobList
 import unittest
 import os
-from job_list import JobList
+import sys
 
 
 class test_job_list(unittest.TestCase):
@@ -12,42 +13,6 @@ class test_job_list(unittest.TestCase):
                 "output_draft": ["student_id", "name", "ex", "score1", "score2", "comment"]
             }
         )
-
-        job_list.run()
-        job_list.student_data["run_job"].sort(
-            key=lambda data: data["student_id"])
-        self.assertEqual(job_list.student_data["run_job"],
-                         [
-                             {'file_name': '12345678_test_ex1.zip',
-                                 'student_id': '12345678', 'name': 'test', 'ex': 'ex1'},
-                         {'file_name': '12345679_test2_ex1.zip',
-                             'student_id': '12345679', 'name': 'test2', 'ex': 'ex1'},
-                         {'file_name': '6310546062_vitvara_ex1.zip',
-                             'student_id': '6310546062', 'name': 'vitvara', 'ex': 'ex1'},
-                         {'file_name': '6310546063_vitvara_ex1.zip', 'student_id': '6310546063',
-                                 'name': 'vitvara', 'ex': 'ex1'},
-                         {'file_name': '6310546064_vitvara_ex1.zip',
-                             'student_id': '6310546064', 'name': 'vitvara', 'ex': 'ex1'},
-                         {'file_name': '6310546065_vitvara_ex1.zip',
-                             'student_id': '6310546065', 'name': 'vitvara', 'ex': 'ex1'},
-                         {'file_name': '6310546066_vitvara_ex1.zip',
-                             'student_id': '6310546066', 'name': 'vitvara', 'ex': 'ex1'}
-                         ]
-                         )
-        self.assertEqual(job_list.invalid_file_name,
-                         ['Unknown File.zip']
-                         )
-
-    def test_recover_app_state(self):
-        job_list = JobList(
-            path_to_run=os.getenv('TAASSISTANT_RUN_PATH'),
-            job_draft={
-                "zip_file_draft": "{student_id}_{name}_{ex}.zip",
-                "output_draft": ["student_id", "name", "ex", "score1", "score2", "comment"]
-            }
-        )
-
-        job_list.run()
 
         # Simmulated Job File Data
         job_file_data = {
@@ -72,13 +37,15 @@ class test_job_list(unittest.TestCase):
                 }
             ]
         }
-        job_list.check_job_done(job_file_data)
-        job_list.student_data["run_job"].sort(
-            key=lambda data: data["student_id"])
-        self.assertEqual(job_list.student_data["run_job"],
-                         [
+        job_list.load_jobs(job_file_data)
+        list_a = [
+            item.generate_dict_report() for item in job_list.jobs
+        ]
+        list_a.sort(
+            key=lambda data: data["file_name"])
+        list_b = [
             {'file_name': '6310546062_vitvara_ex1.zip',
-                         'student_id': '6310546062', 'name': 'vitvara', 'ex': 'ex1'},
+             'student_id': '6310546062', 'name': 'vitvara', 'ex': 'ex1'},
             {'file_name': '6310546063_vitvara_ex1.zip', 'student_id': '6310546063',
              'name': 'vitvara', 'ex': 'ex1'},
             {'file_name': '6310546064_vitvara_ex1.zip',
@@ -88,8 +55,8 @@ class test_job_list(unittest.TestCase):
             {'file_name': '6310546066_vitvara_ex1.zip',
              'student_id': '6310546066', 'name': 'vitvara', 'ex': 'ex1'}
         ]
-        )
-        self.assertEqual(job_list.invalid_file_name,
+        self.assertEqual(list_a, list_b)
+        self.assertEqual(job_list.unknown_files,
                          ['Unknown File.zip']
                          )
 

--- a/core/job_list/test_job_list.py
+++ b/core/job_list/test_job_list.py
@@ -1,7 +1,6 @@
 from job_list import JobList
 import unittest
 import os
-import sys
 
 
 class test_job_list(unittest.TestCase):

--- a/core/main.py
+++ b/core/main.py
@@ -83,10 +83,10 @@ class TaAssistant(TaAssisDisplay):
         accept_job_menu = Menu({
             "a": ("Accept", lambda: self.__trigger_accept_attribute()),
             "d": ("Decline", lambda: self.__decline_job_list()),
-            "j": ("JobList", lambda: self.report_table("Job List", self.__job_list.student_data["run_job"])),
+            "j": ("JobList", lambda: self.report_table("Job List", [item.generate_dict_report() for item in self.__job_list.jobs])),
             "u": ("UnknownList", lambda: self.report_table("Unknown file Result",
                                                            [{"file_name": item}
-                                                               for item in self.__job_list.invalid_file_name]
+                                                               for item in self.__job_list.unknown_files]
                                                            )),
             "z": ("Zip File Draft", lambda: self.notification("Zip File Draft: " + self.__job_draft["zip_file_draft"], "i")),
             "o": ("Output Draft", lambda: self.notification("Output Draft: " + str(self.__job_draft["output_draft"]), "i"))
@@ -112,11 +112,8 @@ class TaAssistant(TaAssisDisplay):
         # Process 2 - Load file
         self.notification("Loading Job list")
         self.__job_list = JobList(path_to_run, self.__job_draft)
-        self.__job_list.run()
-
-        # Process 3 - recover App state
-        self.__job_list.check_job_done(self.__job_file)
+        self.__job_list.load_jobs(self.__job_file)
         self.subnotification("/", "Job list load successfully")
 
-        # Process 4 - Print the result and ask for job confirmation
+        # Process 3 - Print the result and ask for job confirmation
         self.__ask_user_to_accept_job_list()


### PR DESCRIPTION
# ## Description

**Add**

> - **Add** `Job` Object to be used in the jobs attribute instead of using dict.

**Rename**

> - **Rename** attribute in JobList Object from `student_data` to `jobs`
> - **Rename** attribute in JobList Object from `invalid_file_name` to `unknown_files`
> - **Rename** method in JobList Object from `append_studata` to `read_jobs_from_dir`
> - **Rename** method in JobList Object from `check_job_done ` to `categorize_job`

**Update**

> - **Update** `split_name` method in JobList Object to accept `split_list` param and change make it return the truple of these data `(key_list, split_list)`
> - **Update** `split_name` method in JobList Object to accept `split_list` param.
> - **Update** `categorize_job` method in JobList Object to accept `job_file` param.
> - **Update** The JobList to use `Job` Object. Change in `read_jobs_from_dir()`,`categorize_job()`,`` 
> - **Update** Code in main.py to support with the new refactored code.

**Remove**

> - Remove attribute `key_list` from JobList Object
> - Remove attribute `split_list` from JobList Object
> - Remove attribute `work` from JobList Object
> - Remove attribute `rated_student` from JobList Object


## Tests

I added the following tests:

- Edit the old test case to support with the refactoed code.

## Breaking Change

Did any tests fail when you ran them?

- [ ] No, no existing tests failed, so this is _not_ a breaking change.
- [x] Yes, this is a breaking change.
